### PR TITLE
Add Maven assembly descriptor for application

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 This project contains all POMs defining a ETS release.
 
 ## Changelog
-
+### next
+- Add Maven assembly descriptor for application
+- Activate plugins and add dependencies depending on profiles
+### 0.3.0
+- Update scala-maven-plugin to 3.4.1
+- Add akka-http-spray-json and spray-json dependency
+- Rename "service" to "application"
+### 0.2.0
+- Merge ets-poms-dependencies with ets-poms-module-parent
 ### 0.1.0
 - Initial release

--- a/ets-poms-application-parent/pom.xml
+++ b/ets-poms-application-parent/pom.xml
@@ -10,26 +10,47 @@
     <packaging>pom</packaging>
     <name>EShop Technology Stack (ETS) - Application Parent POM</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>net.alchim31.maven</groupId>
-                <artifactId>scala-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <!-- src/main -->
+        <profile>
+            <id>ets-application-main</id>
+            <activation>
+                <file>
+                    <exists>src/main</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>de.kaufhof.ets</groupId>
+                                <artifactId>ets-assembly-descriptors-application</artifactId>
+                                <version>${ets.assembly.descriptors.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>ets-assembly-descriptors-application</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>package-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${ets.scala.compat.version}</artifactId>
-        </dependency>
-    </dependencies>
-
+    </profiles>
 
     <!-- We need a SCM declaration in each file because of
         https://issues.apache.org/jira/browse/MNG-3244

--- a/ets-poms-library-parent/pom.xml
+++ b/ets-poms-library-parent/pom.xml
@@ -13,26 +13,6 @@
     <!-- Currently there is nothing specific here, but if we get special requirements for libraries 
          for packaging / publishing they will be added here -->
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>net.alchim31.maven</groupId>
-                <artifactId>scala-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${ets.scala.compat.version}</artifactId>
-        </dependency>
-    </dependencies>
-
     <!-- We need a SCM declaration in each file because of
         https://issues.apache.org/jira/browse/MNG-3244
         https://issues.apache.org/jira/browse/MNG-2290

--- a/ets-poms-module-parent/pom.xml
+++ b/ets-poms-module-parent/pom.xml
@@ -439,9 +439,69 @@
                         <addDefaultExcludes>false</addDefaultExcludes>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${ets.maven.assembly.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <!-- src/main/scala -->
+        <profile>
+            <id>ets-module-main-scala</id>
+            <activation>
+                <file>
+                    <exists>src/main/scala</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- src/test/scala -->
+        <profile>
+            <id>ets-module-test-scala</id>
+            <activation>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>!true</value>
+                </property>
+                <file>
+                    <exists>src/test/scala</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.scalatest</groupId>
+                        <artifactId>scalatest-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scalatest</groupId>
+                    <artifactId>scalatest_${ets.scala.compat.version}</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <!-- We need a SCM declaration in each file because of
         https://issues.apache.org/jira/browse/MNG-3244

--- a/ets-poms-root-parent/pom.xml
+++ b/ets-poms-root-parent/pom.xml
@@ -107,6 +107,7 @@
         <ets.maven.resource.plugin.version>3.0.2</ets.maven.resource.plugin.version>
         <ets.maven.enforcer.plugin.version>3.0.0-M1</ets.maven.enforcer.plugin.version>
         <ets.maven.projectinforeports.plugin.version>2.9</ets.maven.projectinforeports.plugin.version>
+        <ets.maven.assembly.plugin.version>3.1.0</ets.maven.assembly.plugin.version>
 
         <!-- Other project properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -115,6 +116,7 @@
         <!-- ETS libraries -->
         <ets.akka-stream-utils-core.version>0.1-SNAPSHOT</ets.akka-stream-utils-core.version>
         <ets.filestorage.version>0.1-SNAPSHOT</ets.filestorage.version>
+        <ets.assembly.descriptors.version>0.1.0</ets.assembly.descriptors.version>
     </properties>
 
 


### PR DESCRIPTION
Add the Maven assembly plugin including the assembly descriptor for
application packaging. By default, a tar.gz file is assembled that
includes all JARs (dependencies + application).

Activate plugins only if source folders exist.
* The Scala plugin, Scalatest plugin and the Maven assembly plugin
are activated only if src/main exists
* The Scalatest plugin is activated only if src/test exists